### PR TITLE
[fix] charset toJson

### DIFF
--- a/src/main/java/github/weichware10/util/config/ConfigWriter.java
+++ b/src/main/java/github/weichware10/util/config/ConfigWriter.java
@@ -46,7 +46,7 @@ public final class ConfigWriter {
             // Öffnen der Datei
             File file = new File(location);
             FileOutputStream fos = new FileOutputStream(file);
-            OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+            OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_16);
             BufferedWriter writer = new BufferedWriter(osw);
 
             // Schreiben des JSON

--- a/src/main/java/github/weichware10/util/config/ConfigWriter.java
+++ b/src/main/java/github/weichware10/util/config/ConfigWriter.java
@@ -6,8 +6,11 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import github.weichware10.util.Logger;
 import github.weichware10.util.db.DataBaseClient;
 import java.io.BufferedWriter;
-import java.io.FileWriter;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -41,7 +44,10 @@ public final class ConfigWriter {
             String json = ow.writeValueAsString(configuration);
 
             // Öffnen der Datei
-            BufferedWriter writer = new BufferedWriter(new FileWriter(location, false));
+            File file = new File(location);
+            FileOutputStream fos = new FileOutputStream(file);
+            OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+            BufferedWriter writer = new BufferedWriter(osw);
 
             // Schreiben des JSON
             writer.append(json);

--- a/src/main/java/github/weichware10/util/data/TrialData.java
+++ b/src/main/java/github/weichware10/util/data/TrialData.java
@@ -12,8 +12,10 @@ import github.weichware10.util.Logger;
 import github.weichware10.util.ToolType;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javafx.geometry.Rectangle2D;
@@ -210,7 +212,10 @@ public class TrialData {
             String json = ow.writeValueAsString(trialData);
 
             // Öffnen der Datei
-            BufferedWriter writer = new BufferedWriter(new FileWriter(location, false));
+            File file = new File(location);
+            FileOutputStream fos = new FileOutputStream(file);
+            OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+            BufferedWriter writer = new BufferedWriter(osw);
 
             // Schreiben des JSON
             writer.append(json);

--- a/src/main/java/github/weichware10/util/data/TrialData.java
+++ b/src/main/java/github/weichware10/util/data/TrialData.java
@@ -214,7 +214,7 @@ public class TrialData {
             // Öffnen der Datei
             File file = new File(location);
             FileOutputStream fos = new FileOutputStream(file);
-            OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+            OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_16);
             BufferedWriter writer = new BufferedWriter(osw);
 
             // Schreiben des JSON


### PR DESCRIPTION
Charset als UTF16 spezifiziert, um Umlaute speichern zu können.
Ich weiß, UTF8 müsste eigentlich auch ausreichen, das hat aber nicht funktioniert :(

closes #40 